### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol (MCP) server that provides access to UniProt protein information. This server allows AI assistants to fetch protein function and sequence information directly from UniProt.
 
+<a href="https://glama.ai/mcp/servers/ttjbai3lpx">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/ttjbai3lpx/badge" alt="UniProt Server MCP server" />
+</a>
+
 ## Features
 
 - Get protein information by UniProt accession number


### PR DESCRIPTION
This PR adds a badge for the [UniProt MCP Server](https://glama.ai/mcp/servers/ttjbai3lpx) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/ttjbai3lpx">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/ttjbai3lpx/badge" alt="UniProt Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.